### PR TITLE
call isPlaying function properly

### DIFF
--- a/canvid.js
+++ b/canvid.js
@@ -84,7 +84,7 @@
                             return false;
                         }
 
-                        if(!control.isPlaying){
+                        if(!control.isPlaying()){
                             drawFrame(frameNumber);
                         }
 


### PR DESCRIPTION
setCurrentFrame was not working if the video was not playing, because the control.isPlaying() function was not called properly, as if it was a property instead of a function.

easy fix!
