### PR TITLE
fps must not be a divisor of 60 fix

### DIFF
--- a/canvid.js
+++ b/canvid.js
@@ -15,6 +15,7 @@
                 selector: '.canvid-wrapper'
             },
             firstPlay = true,
+            lastWait = 0,
             control = {
                 play: function() {
                     console.log('Cannot play before images are loaded');
@@ -97,7 +98,7 @@
                     }
 
                     function frame() {
-                        if (!wait) {
+                        if (lastWait > wait) {
                             drawFrame(curFrame);
                             curFrame = (+curFrame + (reverse ? -1 : 1));
                             if (curFrame < 0) curFrame += +opts.frames;
@@ -110,6 +111,7 @@
                                 }
                             }
                         }
+                        lastWait = wait;
                         wait = (wait + 1) % delay;
                         if (playing && opts.frames > 1) requestAnimationFrame(frame);
                     }


### PR DESCRIPTION
In current version fps param should be a divisor of 60 (15, 30, 60 etc). We need it to be 24. This fix will provide needed functionality. Please implement it whatever you want, that's only one way to do it.